### PR TITLE
Allow nullable fields

### DIFF
--- a/src/main/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParser.kt
+++ b/src/main/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParser.kt
@@ -112,7 +112,7 @@ public open class FixedLengthFileParser<T>(
     private fun recordMapperFor(line: String): RecordMapping =
         recordMappings.find { it.lineSelector(line) } ?: throw NoRecordMappingException(line)
 
-    public inline fun <reified R : Any> field(
+    public inline fun <reified R> field(
         from: Int,
         toExclusive: Int,
         padding: Padding = NoPadding,

--- a/src/main/kotlin/br/com/guiabolso/fixedlengthfilehandler/internal/TypeParsers.kt
+++ b/src/main/kotlin/br/com/guiabolso/fixedlengthfilehandler/internal/TypeParsers.kt
@@ -24,11 +24,11 @@ import java.time.LocalDateTime
 import kotlin.reflect.KClass
 
 @PublishedApi
-internal inline fun <reified T : Any> defaultTypeParser(parse: String): T = parse.parseToType(T::class)
+internal inline fun <reified T> defaultTypeParser(parse: String): T = parse.parseToType(T::class)
 
 @Suppress("UNCHECKED_CAST", "IMPLICIT_CAST_TO_ANY")
 @PublishedApi
-internal fun <T : Any> String.parseToType(type: KClass<T>): T {
+internal fun <T> String.parseToType(type: KClass<*>): T {
     return when (type) {
         String::class        -> parseToString()
         Int::class           -> parseToInt()

--- a/src/test/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParserTest.kt
+++ b/src/test/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParserTest.kt
@@ -233,6 +233,25 @@ class FixedLengthFileParserTest : ShouldSpec() {
                 MyUserRecord("ThirdUsernameWithShorterDoc", 123, LocalDate.of(2017, 4, 11))
             )
         }
+        
+        should("Allow nullable record fields") {
+            data class MyRecordWithNullable(val nonNullable: String, val nullable: String?)
+            
+            val stream = """
+                NonNullableNullable   
+                NonNullableNonNullable
+            """.trimmedInputStream()
+            
+            fixedLengthFileParser<MyRecordWithNullable>(stream) {
+                MyRecordWithNullable(
+                    field(0, 11),
+                    field(11, 22) { if(equals("Nullable   ")) null else this }
+                )
+            }.toList() shouldBe listOf(
+                MyRecordWithNullable("NonNullable", null),
+                MyRecordWithNullable("NonNullable", "NonNullable")
+            )
+        }
     }
     
     private fun String.trimmedInputStream(): InputStream = trimIndent().toByteArray().inputStream()

--- a/src/test/kotlin/br/com/guiabolso/fixedlengthfilehandler/internal/TypeParsersTest.kt
+++ b/src/test/kotlin/br/com/guiabolso/fixedlengthfilehandler/internal/TypeParsersTest.kt
@@ -28,43 +28,44 @@ class TypeParsersTest : ShouldSpec() {
     
     init {
         should("Parse String") {
-            "String".parseToType(String::class) shouldBe "String"
+            "String".parseToType<String>(String::class) shouldBe "String"
         }
         
         should("Parse Int") {
-            "123".parseToType(Int::class) shouldBe 123
+            "123".parseToType<Int>(Int::class) shouldBe 123
         }
         
         should("Parse Double") {
-            "123.4567".parseToType(Double::class) shouldBe (123.4567 plusOrMinus 0.0001)
+            "123.4567".parseToType<Double>(Double::class) shouldBe (123.4567 plusOrMinus 0.0001)
         }
         
         should("Parse Long") {
-            Long.MAX_VALUE.toString().parseToType(Long::class) shouldBe Long.MAX_VALUE
+            Long.MAX_VALUE.toString().parseToType<Long>(Long::class) shouldBe Long.MAX_VALUE
         }
         
         should("Parse to Char") {
-            "a".parseToType(Char::class) shouldBe 'a'
+            "a".parseToType<Char>(Char::class) shouldBe 'a'
             shouldThrowAny { "ab".parseToType(Char::class) }
         }
         
         should("Parse to Boolean") {
-            "true".parseToType(Boolean::class) shouldBe true
-            "false".parseToType(Boolean::class) shouldBe false
-            "TRUE".parseToType(Boolean::class) shouldBe true
+            "true".parseToType<Boolean>(Boolean::class) shouldBe true
+            "false".parseToType<Boolean>(Boolean::class) shouldBe false
+            "TRUE".parseToType<Boolean>(Boolean::class) shouldBe true
         }
         
         should("Parse to LocalDate") {
-            "2019-02-09".parseToType(LocalDate::class) shouldBe LocalDate.of(2019, 2, 9)
+            "2019-02-09".parseToType<LocalDate>(LocalDate::class) shouldBe LocalDate.of(2019, 2, 9)
             shouldThrowAny { "2019-2-9".parseToType(LocalDate::class) }
         }
         
         should("Parse to LocalDateTime") {
-            "2019-02-09T03:55:55".parseToType(LocalDateTime::class) shouldBe LocalDateTime.of(2019, 2, 9, 3, 55, 55)
+            "2019-02-09T03:55:55".parseToType<LocalDateTime>(LocalDateTime::class) shouldBe 
+                    LocalDateTime.of(2019, 2, 9, 3, 55, 55)
         }
         
         should("Parse to BigDecimal") {
-            "123456789.123456789".parseToType(BigDecimal::class) shouldBe BigDecimal("123456789.123456789")
+            "123456789.123456789".parseToType<BigDecimal>(BigDecimal::class) shouldBe BigDecimal("123456789.123456789")
         }
     }
 }


### PR DESCRIPTION
The `field` method is constrained to `Any`. However, in some cases, it's possible that one wants to construct a null value depending on a certain logic, for example, a LocalDate represented by the String "00000000" should be null as per `field(0, 8) { if(equals("00000000")) null else toMyLocalDate()  }`

This commit changes that behavior to enable parsing nullable types using `field`.

The `parseToType`, `defaultTypeParser` methods were changed in a way that their tests had to change as well. This won't break current users as these functions are internal and not intended for external users.

Closes #8