### PR TITLE
Add overload to field

### DIFF
--- a/src/main/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParser.kt
+++ b/src/main/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParser.kt
@@ -122,6 +122,19 @@ public open class FixedLengthFileParser<T>(
         val stringWithRemovedPadding = padding.removePadding(stringBlock)
         return stringWithRemovedPadding.unpaddedValueParser()
     }
+
+    /**
+     * Field will start at [from] and will stop at the end of the line
+     */
+    public inline fun <reified R> field(
+        from: Int,
+        padding: Padding = NoPadding,
+        unpaddedValueParser: String.() -> R = ::defaultTypeParser
+    ): R {
+        val stringBlock = currentLine.substring(from)
+        val stringWithRemovedPadding = padding.removePadding(stringBlock)
+        return stringWithRemovedPadding.unpaddedValueParser()
+    }
     
     public inline fun <reified R : Number> decimalField(
         from: Int,

--- a/src/test/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParserTest.kt
+++ b/src/test/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParserTest.kt
@@ -268,6 +268,24 @@ class FixedLengthFileParserTest : ShouldSpec() {
                 MyRecordWithEnum(MyEnum.BAR, "STR")
             )
         }
+        
+        should("Parse until end of the line if it's not padded with whitespaces") {
+            data class MyRecord(val first: String, val second: String)
+            
+            val stream = """
+                FirstStrSecondStr
+                FirstStrS
+                FirstStrSecondStr
+            """.trimmedInputStream()
+            
+            fixedLengthFileParser<MyRecord>(stream) {
+                MyRecord(field(0, 8), field(8))
+            }.toList() shouldBe listOf(
+                MyRecord("FirstStr", "SecondStr"),
+                MyRecord("FirstStr", "S"),
+                MyRecord("FirstStr", "SecondStr")
+            )
+        }
     }
     
     private fun String.trimmedInputStream(): InputStream = trimIndent().toByteArray().inputStream()


### PR DESCRIPTION
This commit adds an overload to the field method to allow its behavior to be consistent with `String.substring`, in which you can define a substring to go from a starting point until the end of the line.

With this commit, this behavior will be possible.

Closes #16