### PR TITLE
Add LineParseException

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 apply(plugin = "com.novoda.bintray-release")
 
 group = "br.com.guiabolso"
-version = "0.4.0"
+version = "0.5.0"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParser.kt
+++ b/src/main/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParser.kt
@@ -102,10 +102,16 @@ public open class FixedLengthFileParser<T>(
     @PublishedApi
     internal var recordMappings: MutableList<RecordMapping> = recordMappings.toMutableList()
 
+    @Suppress("TooGenericExceptionCaught")
     public fun buildSequence(): Sequence<T> {
         return fileStream.bufferedReader().lineSequence().map {
             currentLine = it
-            recordMapperFor(it).recordBuilder(this)
+
+            try {
+                recordMapperFor(it).recordBuilder(this)
+            } catch (exception: Exception) {
+                throw LineParseException(currentLine, exception)
+            }
         }
     }
 
@@ -171,3 +177,8 @@ public class MultiFixedLengthFileParser<T>(
 public class NoRecordMappingException(
     public val line: String
 ) : RuntimeException("There are no valid record mappers for line $line")
+
+public class LineParseException(
+    public val line: String,
+    public override val cause: Exception
+) : RuntimeException("Failed to parse line", cause)

--- a/src/test/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParserTest.kt
+++ b/src/test/kotlin/br/com/guiabolso/fixedlengthfilehandler/FixedLengthFileParserTest.kt
@@ -203,7 +203,7 @@ class FixedLengthFileParserTest : ShouldSpec() {
                 cccc
             """.trimmedInputStream()
     
-            shouldThrow<NoRecordMappingException> {
+            shouldThrow<LineParseException> {
                 multiFixedLengthFileParser<String>(stream) {
                     withRecord({ it.contains("b") }) {
                         field<String>(0, 4)
@@ -285,6 +285,22 @@ class FixedLengthFileParserTest : ShouldSpec() {
                 MyRecord("FirstStr", "S"),
                 MyRecord("FirstStr", "SecondStr")
             )
+        }
+
+        should("Throw ParseException if there was a line parsing problem") {
+            data class Foo(val string: String, val date: LocalDate)
+
+            val stream = """
+                aaaa2019-02-09
+                bbbb2019-ER-10
+                cccc2019-04-11
+            """.trimmedInputStream()
+
+            shouldThrow<LineParseException> {
+                fixedLengthFileParser<Foo>(stream) {
+                    Foo(field(0, 4), field(4, 13))
+                }.toList()
+            }
         }
     }
     


### PR DESCRIPTION
Sometimes, when parsing a line with some sort of unexpected content, is hard to track down the line where this occurred, specially on large files. 

This pull request adds the LineParseException, which encapsulates all sort of errors which might occur when trying to parse any line. If necessary, it will be possible to access the line which generated the error.